### PR TITLE
Add ability to uninstall Blackfire from a server

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -122,6 +122,7 @@ $forge->updateSiteNginxFile($serverId, $siteId, $content)
 
 // Blackfire
 $forge->installBlackfire($serverId, array $data)
+$forge->removeBlackfire($serverId)
 
 // Papertrail
 $forge->installPapertrail($serverId, array $data)

--- a/src/Actions/ManagesServers.php
+++ b/src/Actions/ManagesServers.php
@@ -175,6 +175,17 @@ trait ManagesServers
     }
 
     /**
+     * Remove Blackfire from the server.
+     *
+     * @param  string $serverId
+     * @return void
+     */
+    public function removeBlackfire($serverId)
+    {
+        $this->delete("servers/$serverId/blackfire/remove");
+    }
+
+    /**
      * Install Papertrail on the server.
      *
      * @param  string $serverId


### PR DESCRIPTION
The endpoint exists, as documented [here](https://forge.laravel.com/api-documentation#remove-blackfire).