### PR TITLE
Use correct method as per documentation for restarting Daemon

### DIFF
--- a/src/Actions/ManagesDaemons.php
+++ b/src/Actions/ManagesDaemons.php
@@ -68,7 +68,7 @@ trait ManagesDaemons
      */
     public function restartDaemon($serverId, $daemonId, $wait = true)
     {
-        $this->put("servers/$serverId/daemons/$daemonId/restart");
+        $this->post("servers/$serverId/daemons/$daemonId/restart");
 
         if ($wait) {
             $this->retry(30, function () use ($serverId, $daemonId) {


### PR DESCRIPTION
Calling the restart daemon methods would would fail was because it's sending a PUT request but Forge API documentation states that it accepts only a POST request for that action.