### PR TITLE
Use the 'command' attribute in the Job resource

### DIFF
--- a/src/Resources/Job.php
+++ b/src/Resources/Job.php
@@ -19,11 +19,11 @@ class Job extends Resource
     public $serverId;
 
     /**
-     * The name of the job.
+     * The command of the job.
      *
      * @var string
      */
-    public $name;
+    public $command;
 
     /**
      * The user that runs the job on the server.


### PR DESCRIPTION
Just a small fix, but noticed that the `name` attribute was defined in the resource instead of the `command` attribute. This makes it conform the response from the API / docs :)