### PR TITLE
Increase the wait time for obtaining Lets Encrypt certificates

### DIFF
--- a/src/Actions/ManagesCertificates.php
+++ b/src/Actions/ManagesCertificates.php
@@ -146,7 +146,7 @@ trait ManagesCertificates
         $certificate = $this->post("servers/$serverId/sites/$siteId/certificates/letsencrypt", $data)['certificate'];
 
         if ($wait) {
-            return $this->retry(30, function () use ($serverId, $siteId, $certificate) {
+            return $this->retry(60, function () use ($serverId, $siteId, $certificate) {
                 $certificate = $this->certificate($serverId, $siteId, $certificate['id']);
 
                 return $certificate->status == 'installed' ? $certificate : null;


### PR DESCRIPTION
Noticed that in the most cases when requesting a certificate, the request was around +/- 30 seconds. But sometimes the time was > 30s, which made the wait request time-out. This increases the wait period a bit to allow some more space before timing-out.