### PR TITLE
Fixed call to siteDeploymentScript() in Site::getDeploymentScript()

### DIFF
--- a/src/Resources/Site.php
+++ b/src/Resources/Site.php
@@ -189,7 +189,7 @@ class Site extends Resource
      */
     public function getDeploymentScript()
     {
-        return $this->forge->siteDeploymentLog($this->serverId, $this->id);
+        return $this->forge->siteDeploymentScript($this->serverId, $this->id);
     }
 
     /**


### PR DESCRIPTION
Hi !

There was a call to the wrong method in the Site::getDeploymentScript() method.

Here's a fix.

Thank you for your work.