### PR TITLE
Add wait param to git repo actions

### DIFF
--- a/src/Actions/ManagesSites.php
+++ b/src/Actions/ManagesSites.php
@@ -154,7 +154,7 @@ trait ManagesSites
      * @param  integer $serverId
      * @param  integer $siteId
      * @param  array $data
-     * @param boolean $wait
+     * @param  boolean $wait
      * @return void
      */
     public function installGitRepositoryOnSite($serverId, $siteId, array $data, $wait = false)
@@ -187,7 +187,7 @@ trait ManagesSites
      *
      * @param  integer $serverId
      * @param  integer $siteId
-     * @param boolean $wait
+     * @param  boolean $wait
      * @return void
      */
     public function destroySiteGitRepository($serverId, $siteId, $wait = false)

--- a/src/Actions/ManagesSites.php
+++ b/src/Actions/ManagesSites.php
@@ -154,11 +154,19 @@ trait ManagesSites
      * @param  integer $serverId
      * @param  integer $siteId
      * @param  array $data
+     * @param boolean $wait
      * @return void
      */
-    public function installGitRepositoryOnSite($serverId, $siteId, array $data)
+    public function installGitRepositoryOnSite($serverId, $siteId, array $data, $wait = false)
     {
         $this->post("servers/$serverId/sites/$siteId/git", $data);
+
+        if ($wait) {
+            $this->retry($this->getTimeout(), function () use ($serverId, $siteId) {
+                $site = $this->site($serverId, $siteId);
+                return $site->repositoryStatus === 'installed' ? $site : null;
+            });
+        }
     }
 
     /**
@@ -179,11 +187,19 @@ trait ManagesSites
      *
      * @param  integer $serverId
      * @param  integer $siteId
+     * @param boolean $wait
      * @return void
      */
-    public function destroySiteGitRepository($serverId, $siteId)
+    public function destroySiteGitRepository($serverId, $siteId, $wait = false)
     {
         $this->delete("servers/$serverId/sites/$siteId/git");
+
+        if ($wait) {
+            $this->retry($this->getTimeout(), function () use ($serverId, $siteId) {
+                $site = $this->site($serverId, $siteId);
+                return is_null($site->repositoryStatus) ? $site : null;
+            });
+        }
     }
 
     /**

--- a/src/Resources/Site.php
+++ b/src/Resources/Site.php
@@ -154,11 +154,12 @@ class Site extends Resource
      * Install a git repository on the given site.
      *
      * @param  array $data
+     * @param  boolean $wait
      * @return void
      */
-    public function installGitRepository(array $data)
+    public function installGitRepository(array $data, $wait = false)
     {
-        return $this->forge->installGitRepositoryOnSite($this->serverId, $this->id, $data);
+        return $this->forge->installGitRepositoryOnSite($this->serverId, $this->id, $data, $wait);
     }
 
     /**
@@ -175,11 +176,12 @@ class Site extends Resource
     /**
      * Destroy the git-based project installed on the site.
      *
+     * @param boolean $wait
      * @return void
      */
-    public function destroyGitRepository()
+    public function destroyGitRepository($wait = false)
     {
-        return $this->forge->destroySiteGitRepository($this->serverId, $this->id);
+        return $this->forge->destroySiteGitRepository($this->serverId, $this->id, $wait);
     }
 
     /**


### PR DESCRIPTION
I tested it with this:

```php
$site = $this->forge->site(env('WP_SERVER'), env('WP_SITE'));
var_dump($site->repositoryStatus);

$site->installGitRepository([
    'provider' => 'github',
    'repository' => env('WP_REPO'),
    'branch' => 'master'
], true);

$site = $this->forge->site(env('WP_SERVER'), env('WP_SITE'));
var_dump($site->repositoryStatus);

$site->destroyGitRepository(true);

$site = $this->forge->site(env('WP_SERVER'), env('WP_SITE'));
var_dump($site->repositoryStatus);
die();
```

<img width="686" alt="screen shot 2018-11-05 at 10 34 53 pm" src="https://user-images.githubusercontent.com/1478421/48007959-474fa980-e14b-11e8-94e5-8ca9598520b1.png">
