### PR TITLE
Updating a recipe should also return a Recipe resource

### DIFF
--- a/src/Actions/ManagesRecipes.php
+++ b/src/Actions/ManagesRecipes.php
@@ -49,7 +49,7 @@ trait ManagesRecipes
      */
     public function updateRecipe($recipeId, array $data)
     {
-        return $this->put("recipes/$recipeId", $data)['recipe'];
+        return new Recipe($this->put("recipes/$recipeId", $data)['recipe']);
     }
 
     /**


### PR DESCRIPTION
A created recipe returns a `Recipe` resource object, however an updated one simply returns an array.

```php
$recipe = $this->api->createRecipe();

$updatedRecipe = $this->api->updateRecipe(
    $recipe->id // Access as object successfully
);

echo $updatedRecipe['id']; // Works, it's an array!
echo $updatedRecipe->id; // Error: Trying to get property 'id' of non-object
```