### PR TITLE
Add Backup API

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -403,6 +403,7 @@ On a BackupConfiguration Instance you may also call:
 
 ```php
 
+$extendedConfig = $backupConfig->get(); // Load the databases also
 $backupConfig->delete();
 $backupConfig->restoreBackup($backupId);
 $backupConfig->deleteBackup($backupId);

--- a/readme.md
+++ b/readme.md
@@ -390,10 +390,10 @@ $recipe->run(array $data);
 ## Managing Backups
 
 ```php
-$forge->backupConfigs($serverId);
-$forge->createBackupConfig($serverId, array $data);
-$forge->backupConfig($serverId, $backupConfigurationId);
-$forge->deleteBackupConfig($serverId, $backupConfigurationId);
+$forge->backupConfigurations($serverId);
+$forge->createBackupConfiguration($serverId, array $data);
+$forge->backupConfiguration($serverId, $backupConfigurationId);
+$forge->deleteBackupConfiguration($serverId, $backupConfigurationId);
 $forge->restoreBackup($serverId, $backupConfigurationId, $backupId);
 $forge->deleteBackup($serverId, $backupConfigurationId, $backupId);
 
@@ -406,6 +406,14 @@ On a BackupConfiguration Instance you may also call:
 $backupConfig->delete();
 $backupConfig->restoreBackup($backupId);
 $backupConfig->deleteBackup($backupId);
+```
+
+On a Backup Instance you may also call:
+
+```php
+
+$backupConfig->delete();
+$backupConfig->restore();
 ```
 
 ## Testing

--- a/readme.md
+++ b/readme.md
@@ -387,6 +387,26 @@ $recipe->delete();
 $recipe->run(array $data);
 ```
 
+## Managing Backups
+
+```php
+$forge->backupConfigs($serverId);
+$forge->createBackupConfig($serverId, array $data);
+$forge->backupConfig($serverId, $backupConfigurationId);
+$forge->deleteBackupConfig($serverId, $backupConfigurationId);
+$forge->restoreBackup($serverId, $backupConfigurationId, $backupId);
+$forge->deleteBackup($serverId, $backupConfigurationId, $backupId);
+
+```
+
+On a BackupConfiguration Instance you may also call:
+
+```php
+
+$backupConfig->delete();
+$backupConfig->restoreBackup($backupId);
+$backupConfig->deleteBackup($backupId);
+```
 
 ## Testing
 

--- a/src/Actions/ManagesBackups.php
+++ b/src/Actions/ManagesBackups.php
@@ -48,7 +48,7 @@ trait ManagesBackups
     {
         $response = $this->post("servers/{$serverId}/backup-configs", $data);
 
-        return new BackupConfiguration($response['backup']+ ['server_id' => $serverId], $this);
+        return new BackupConfiguration($response['backup'] + ['server_id' => $serverId], $this);
     }
 
     /**

--- a/src/Actions/ManagesBackups.php
+++ b/src/Actions/ManagesBackups.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Themsaid\Forge\Actions;
+
+use Themsaid\Forge\Resources\BackupConfiguration;
+use Themsaid\Forge\Resources\Event;
+use Themsaid\Forge\Resources\Server;
+
+trait ManagesBackups
+{
+    /**
+     * Get the collection of backup configurations.
+     *
+     * @param  string $serverId
+     * @return \Themsaid\Forge\Resources\BackupConfiguration[]
+     */
+    public function backupConfigs($serverId)
+    {
+        return $this->transformCollection(
+            $this->get("servers/$serverId/backup-configs")['backups'],
+            BackupConfiguration::class,
+            ['server_id' => $serverId]
+        );
+    }
+
+    /**
+     * Get a backup configuration.
+     *
+     * @param  string $serverId
+     * @param  string $backupConfigurationId
+     * @return BackupConfiguration
+     */
+    public function backupConfig($serverId, $backupConfigurationId)
+    {
+        return new BackupConfiguration(
+            $this->get("servers/{$serverId}/backup-configs/{$backupConfigurationId}")['backup']
+            + ['server_id' => $serverId], $this);
+    }
+
+    /**
+     * Create a new backup configuration.
+     *
+     * @param  string $serverId
+     * @param  array $data
+     * @return BackupConfiguration
+     */
+    public function createBackupConfig($serverId, array $data)
+    {
+        $response = $this->post("servers/{$serverId}/backup-configs", $data);
+
+        return new BackupConfiguration($response['backup']+ ['server_id' => $serverId], $this);
+    }
+
+    /**
+     * Delete a backup configuration.
+     *
+     * @param  string $serverId
+     * @param  string $backupConfigurationId
+     */
+    public function deleteBackupConfig($serverId, $backupConfigurationId)
+    {
+         $this->delete("servers/{$serverId}/backup-configs/{$backupConfigurationId}");
+    }
+
+    /**
+     * Restore a backup.
+     *
+     * @param  string $serverId
+     * @param  string $backupConfigurationId
+     * @param  string $backupId
+     */
+    public function restoreBackup($serverId, $backupConfigurationId, $backupId)
+    {
+        $this->post("servers/{$serverId}/backup-configs/{$backupConfigurationId}/backups/{$backupId}");
+    }
+
+    /**
+     * Delete a backup.
+     *
+     * @param  string $serverId
+     * @param  string $backupConfigurationId
+     * @param  string $backupId
+     */
+    public function deleteBackup($serverId, $backupConfigurationId, $backupId)
+    {
+        $this->delete("servers/{$serverId}/backup-configs/{$backupConfigurationId}/backups/{$backupId}");
+    }
+}

--- a/src/Actions/ManagesBackups.php
+++ b/src/Actions/ManagesBackups.php
@@ -14,7 +14,7 @@ trait ManagesBackups
      * @param  string $serverId
      * @return \Themsaid\Forge\Resources\BackupConfiguration[]
      */
-    public function backupConfigs($serverId)
+    public function backupConfigurations($serverId)
     {
         return $this->transformCollection(
             $this->get("servers/$serverId/backup-configs")['backups'],
@@ -30,7 +30,7 @@ trait ManagesBackups
      * @param  string $backupConfigurationId
      * @return BackupConfiguration
      */
-    public function backupConfig($serverId, $backupConfigurationId)
+    public function backupConfiguration($serverId, $backupConfigurationId)
     {
         return new BackupConfiguration(
             $this->get("servers/{$serverId}/backup-configs/{$backupConfigurationId}")['backup']
@@ -44,7 +44,7 @@ trait ManagesBackups
      * @param  array $data
      * @return BackupConfiguration
      */
-    public function createBackupConfig($serverId, array $data)
+    public function createBackupConfiguration($serverId, array $data)
     {
         $response = $this->post("servers/{$serverId}/backup-configs", $data);
 
@@ -57,7 +57,7 @@ trait ManagesBackups
      * @param  string $serverId
      * @param  string $backupConfigurationId
      */
-    public function deleteBackupConfig($serverId, $backupConfigurationId)
+    public function deleteBackupConfiguration($serverId, $backupConfigurationId)
     {
          $this->delete("servers/{$serverId}/backup-configs/{$backupConfigurationId}");
     }

--- a/src/Forge.php
+++ b/src/Forge.php
@@ -15,6 +15,7 @@ class Forge
         Actions\ManagesWorkers,
         Actions\ManagesSSHKeys,
         Actions\ManagesRecipes,
+        Actions\ManagesBackups,
         Actions\ManagesWebhooks,
         Actions\ManagesMysqlUsers,
         Actions\ManagesCredentials,

--- a/src/Resources/Backup.php
+++ b/src/Resources/Backup.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Themsaid\Forge\Resources;
+
+class Backup extends Resource
+{
+    /**
+     * The id of the backup.
+     *
+     * @var integer
+     */
+    public $id;
+
+    /**
+     * The id of the server.
+     *
+     * @var integer
+     */
+    public $serverId;
+
+    /**
+     * The id of the database.
+     *
+     * @var integer
+     */
+    public $backupConfigurationId;
+
+    /**
+     * The status of the backup.
+     *
+     * @var string
+     */
+    public $status;
+
+    /**
+     * The status of the restore.
+     *
+     * @var string
+     */
+    public $restoreStatus;
+
+    /**
+     * The archive path.
+     *
+     * @var string
+     */
+    public $archivePath;
+
+    /**
+     * The size of the backup
+     *
+     * @var int
+     */
+    public $size;
+
+    /**
+     * The uuid of this backup
+     *
+     * @var string
+     */
+    public $uuid;
+
+    /**
+     * The duration of this backup
+     *
+     * @var string
+     */
+    public $duration;
+
+    /**
+     * The backup date.
+     *
+     * @var string|null
+     */
+    public $lastBackupTime;
+
+    /**
+     * The date/time the backup was created.
+     *
+     * @var string
+     */
+    public $createdAt;
+
+    /**
+     * Restore this backup.
+     *
+     *
+     * @return void
+     */
+    public function restore()
+    {
+        $this->forge->restoreBackup($this->serverId, $this->backupConfigurationId, $this->id);
+    }
+
+    /**
+     * Delete this backup.
+     *
+     * @return void
+     */
+    public function delete()
+    {
+        $this->forge->deleteBackup($this->serverId, $this->backupConfigurationId, $this->id);
+    }
+}

--- a/src/Resources/BackupConfiguration.php
+++ b/src/Resources/BackupConfiguration.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace Themsaid\Forge\Resources;
+
+class BackupConfiguration extends Resource
+{
+    /**
+     * The id of the backup.
+     *
+     * @var integer
+     */
+    public $id;
+
+    /**
+     * The id of the server.
+     *
+     * @var integer
+     */
+    public $serverId;
+
+    /**
+     * The id of the database.
+     *
+     * @var integer
+     */
+    public $databaseId;
+
+    /**
+     * The day of the week: 0 (Sunday) - 6 (Saturday).
+     *
+     * @var int|null
+     */
+    public $dayOfWeek;
+
+    /**
+     * The time of the backup in 24 hour format.
+     *
+     * @var string
+     */
+    public $time;
+
+    /**
+     * The provider (s3 or spaces)
+     *
+     * @var boolean
+     */
+    public $provider;
+
+    /**
+     * The name for the provider
+     *
+     * @var string
+     */
+    public $providerName;
+
+    /**
+     * The last Backup time
+     *
+     * @var string|null
+     */
+    public $lastBackupTime;
+
+    /**
+     * The databases for this backup
+     *
+     * @var array
+     */
+    public $databases;
+
+    /**
+     * The databases for this backup
+     *
+     * @var array
+     */
+    public $logs;
+
+    /**
+     * The databases for this backup
+     *
+     * @var array
+     */
+    public $backups;
+
+
+    /**
+     * The date/time the certificate was created.
+     *
+     * @var string
+     */
+    public $createdAt;
+
+    /**
+     * Delete the given recipe.
+     *
+     * @return void
+     */
+    public function delete()
+    {
+        $this->forge->deleteBackupConfig($this->serverId, $this->id);
+    }
+
+    /**
+     * Restore a backup for this configuration.
+     *
+     * @param $backupId
+     *
+     * @return void
+     */
+    public function restoreBackup($backupId)
+    {
+        $this->forge->restoreBackup($this->serverId, $this->id, $backupId);
+    }
+
+    /**
+     * Delete the given recipe.
+     *
+     * @param $backupId
+     *
+     * @return void
+     */
+    public function deleteBackup($backupId)
+    {
+        $this->forge->deleteBackup($this->serverId, $this->id, $backupId);
+    }
+}

--- a/src/Resources/BackupConfiguration.php
+++ b/src/Resources/BackupConfiguration.php
@@ -94,16 +94,6 @@ class BackupConfiguration extends Resource
     }
 
     /**
-     * Get the given backup configuration.
-     *
-     * @return static
-     */
-    public function get()
-    {
-        return $this->forge->backupConfiguration($this->serverId, $this->id);
-    }
-
-    /**
      * Delete the given configuration.
      *
      * @return void

--- a/src/Resources/BackupConfiguration.php
+++ b/src/Resources/BackupConfiguration.php
@@ -70,14 +70,7 @@ class BackupConfiguration extends Resource
     /**
      * The databases for this backup
      *
-     * @var array
-     */
-    public $logs;
-
-    /**
-     * The databases for this backup
-     *
-     * @var array
+     * @var array|null
      */
     public $backups;
 

--- a/src/Resources/BackupConfiguration.php
+++ b/src/Resources/BackupConfiguration.php
@@ -58,14 +58,14 @@ class BackupConfiguration extends Resource
      *
      * Note: this is only available when getting a single configuration.
      *
-     * @var array
+     * @var \Themsaid\Forge\Resources\MysqlDatabase[]
      */
     public $databases;
 
     /**
      * The databases for this backup
      *
-     * @var array
+     * @var \Themsaid\Forge\Resources\Backup[]
      */
     public $backups;
 

--- a/src/Resources/BackupConfiguration.php
+++ b/src/Resources/BackupConfiguration.php
@@ -19,13 +19,6 @@ class BackupConfiguration extends Resource
     public $serverId;
 
     /**
-     * The id of the database.
-     *
-     * @var integer
-     */
-    public $databaseId;
-
-    /**
      * The day of the week: 0 (Sunday) - 6 (Saturday).
      *
      * @var int|null
@@ -61,7 +54,9 @@ class BackupConfiguration extends Resource
     public $lastBackupTime;
 
     /**
-     * The databases for this backup
+     * The databases for this backup.
+     *
+     * Note: this is only available when getting a single configuration.
      *
      * @var array
      */
@@ -70,26 +65,52 @@ class BackupConfiguration extends Resource
     /**
      * The databases for this backup
      *
-     * @var array|null
+     * @var array
      */
     public $backups;
 
-
     /**
-     * The date/time the certificate was created.
+     * The date/time the configuration was created.
      *
      * @var string
      */
     public $createdAt;
 
+    public function __construct(array $attributes, $forge = null)
+    {
+        parent::__construct($attributes, $forge);
+
+        $this->databases = $this->transformCollection(
+            $this->databases ?: [],
+            MysqlDatabase::class,
+            ['server_id' => $this->serverId]
+        );
+
+        $this->backups = $this->transformCollection(
+            $this->backups,
+            Backup::class,
+            ['server_id' => $this->serverId]
+        );
+    }
+
     /**
-     * Delete the given recipe.
+     * Get the given backup configuration.
+     *
+     * @return static
+     */
+    public function get()
+    {
+        return $this->forge->backupConfiguration($this->serverId, $this->id);
+    }
+
+    /**
+     * Delete the given configuration.
      *
      * @return void
      */
     public function delete()
     {
-        $this->forge->deleteBackupConfig($this->serverId, $this->id);
+        $this->forge->deleteBackupConfiguration($this->serverId, $this->id);
     }
 
     /**
@@ -105,7 +126,7 @@ class BackupConfiguration extends Resource
     }
 
     /**
-     * Delete the given recipe.
+     * Delete the given backup.
      *
      * @param $backupId
      *

--- a/src/Resources/Resource.php
+++ b/src/Resources/Resource.php
@@ -78,7 +78,7 @@ class Resource
     protected function transformCollection($collection, $class, $extraData = [])
     {
         return array_map(function ($data) use ($class, $extraData) {
-            return new $class($data + $extraData, $this);
+            return new $class($data + $extraData, $this->forge);
         }, $collection);
     }
 }

--- a/src/Resources/Resource.php
+++ b/src/Resources/Resource.php
@@ -66,4 +66,19 @@ class Resource
 
         return str_replace(' ', '', implode(' ', $parts));
     }
+
+    /**
+     * Transform the items of the collection to the given class.
+     *
+     * @param  array $collection
+     * @param  string $class
+     * @param  array $extraData
+     * @return array
+     */
+    protected function transformCollection($collection, $class, $extraData = [])
+    {
+        return array_map(function ($data) use ($class, $extraData) {
+            return new $class($data + $extraData, $this);
+        }, $collection);
+    }
 }


### PR DESCRIPTION
Adds methods to manage backups with the API.

- The list of configurations does not contain the databases, only the request for a specific config
- Do I need to create a resource for the Backups itself also? Or just keep it as an array. Is there an example that creates sub resources?
- If that's not a bug, should I add a 'get' or 'load' method to the config to load additional data?
